### PR TITLE
Use new package download URLs

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -46,7 +46,7 @@ define vagrant::package (
 
   # Determine the base url (it depends on the version)
   if versioncmp($version_real, '1.4.0') >= 0 {
-    $base_url = 'https://dl.bintray.com/mitchellh/vagrant'
+    $base_url = "https://releases.hashicorp.com/vagrant/${version_real}"
     $darwin_prefix = 'vagrant_'
     $windows_prefix = 'vagrant_'
   } else {


### PR DESCRIPTION
With vagrant 1.8.0 on, the binaries have moved to
releases.hashicorp.com.

The old bintray.com URLs have binaries for versions [1.4.0, 1.7.4], but
releases.hashicorp.com has everything >= 1.4.0 so bintray isn't used at all
anymore.
