### PR TITLE
Replace validate_bool()

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,15 +37,13 @@
 #
 
 class vagrant (
-  $version                = $vagrant::params::version,
-  $ensure                 = $vagrant::params::ensure,
-  $install_from_source    = $vagrant::params::install_from_source,
-  $source                 = $vagrant::params::source,
-  $provider               = $vagrant::params::provider,
-  $path                   = $vagrant::params::path
+  $version                     = $vagrant::params::version,
+  $ensure                      = $vagrant::params::ensure,
+  Boolean $install_from_source = $vagrant::params::install_from_source,
+  $source                      = $vagrant::params::source,
+  $provider                    = $vagrant::params::provider,
+  $path                        = $vagrant::params::path
 ) inherits vagrant::params {
-
-  validate_bool($install_from_source)
 
   if $install_from_source {
     vagrant::package {"vagrant-${version}":

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -57,18 +57,16 @@
 #
 
 define vagrant::plugin (
-  $ensure       = present,
-  $plugin       = $title,
-  $version      = undef,
-  $user         = $::id,
-  $source       = undef,
-  $prerelease   = false,
-  $entry_point  = undef,
-  $path         = undef,
-  $timeout      = 0
+  $ensure             = present,
+  $plugin             = $title,
+  $version            = undef,
+  $user               = $::id,
+  $source             = undef,
+  Boolean $prerelease = false,
+  $entry_point        = undef,
+  $path               = undef,
+  $timeout            = 0
 ) {
-
-  validate_bool($prerelease)
 
   $check_cmd = "${vagrant::params::vagrant} plugin list | ${vagrant::params::grep} \"^${plugin} \""
 


### PR DESCRIPTION
This function isn't supported by Puppet 7 anymore. Use types to ensure only valid values are passed.